### PR TITLE
Merge BaseFeePerGas fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN apk --no-cache add libstdc++ libgcc
 COPY --from=build-env /src/bin /app/
 COPY --from=build-env /src/phase0.yml /app/phase0.yml
 COPY  ./config-example.yml /app/config.yml
-CMD ["./explorer", "--config", "config.yml"]
+CMD []

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ explorer:
 	go run cmd/bundle/main.go
 	cp -r static/ bin/static
 	cp -r locales/ bin/
-	go install github.com/swaggo/swag/cmd/swag@v1.7.0 && swag init -g handlers/api.go
+	go get github.com/swaggo/swag/cmd/swag@v1.7.0 && swag init -g handlers/api.go
 	go build --ldflags=${LDFLAGS} -o bin/explorer cmd/explorer/main.go
 
 chartshotter:

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -14,6 +14,7 @@ import (
 	"eth2-exporter/utils"
 	"flag"
 	"fmt"
+	"math/big"
 	"net/http"
 	"os"
 	"time"
@@ -96,17 +97,18 @@ func main() {
 	if utils.Config.Indexer.Enabled {
 		var rpcClient rpc.Client
 
+		chainID := new(big.Int).SetUint64(utils.Config.Chain.DepositChainID)
 		if utils.Config.Indexer.Node.Type == "prysm" {
 			if utils.Config.Indexer.Node.PageSize == 0 {
 				logrus.Printf("setting default rpc page size to 500")
 				utils.Config.Indexer.Node.PageSize = 500
 			}
-			rpcClient, err = rpc.NewPrysmClient(cfg.Indexer.Node.Host+":"+cfg.Indexer.Node.Port, int64(cfg.Chain.DepositChainID))
+			rpcClient, err = rpc.NewPrysmClient(cfg.Indexer.Node.Host+":"+cfg.Indexer.Node.Port, chainID)
 			if err != nil {
 				logrus.Fatal(err)
 			}
 		} else if utils.Config.Indexer.Node.Type == "lighthouse" {
-			rpcClient, err = rpc.NewLighthouseClient("http://" + cfg.Indexer.Node.Host + ":" + cfg.Indexer.Node.Port)
+			rpcClient, err = rpc.NewLighthouseClient("http://"+cfg.Indexer.Node.Host+":"+cfg.Indexer.Node.Port, chainID)
 			if err != nil {
 				logrus.Fatal(err)
 			}

--- a/db/db.go
+++ b/db/db.go
@@ -3,7 +3,6 @@ package db
 import (
 	"bytes"
 	"database/sql"
-	"encoding/binary"
 	"eth2-exporter/metrics"
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
@@ -1333,7 +1332,7 @@ func saveBlocks(blocks map[uint64]map[string]*types.Block, tx *sql.Tx) error {
 				gasUsed = b.ExecutionPayload.GasUsed
 				timestamp = b.ExecutionPayload.Timestamp
 				extraData = b.ExecutionPayload.ExtraData
-				baseFeePerGas = binary.BigEndian.Uint64(b.ExecutionPayload.BaseFeePerGas[32-8:])
+				baseFeePerGas = b.ExecutionPayload.BaseFeePerGas
 				blockHash = b.ExecutionPayload.BlockHash
 				txCount = len(b.ExecutionPayload.Transactions)
 			}

--- a/exporter/eth1.go
+++ b/exporter/eth1.go
@@ -2,12 +2,14 @@ package exporter
 
 import (
 	"context"
+	"encoding/hex"
 	"eth2-exporter/db"
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
 	"fmt"
 	"math/big"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum"
@@ -158,9 +160,13 @@ func fetchEth1Deposits(fromBlock, toBlock uint64) (depositsToSave []*types.Eth1D
 	txsToFetch := []string{}
 
 	cfg := params.BeaconConfig()
+	genForkVersion, err := hex.DecodeString(strings.Replace(utils.Config.Chain.Phase0.GenesisForkVersion, "0x", "", -1))
+	if err != nil {
+		return nil, err
+	}
 	domain, err := helpers.ComputeDomain(
 		cfg.DomainDeposit,
-		cfg.GenesisForkVersion,
+		genForkVersion,
 		cfg.ZeroHash[:],
 	)
 	if utils.Config.Chain.Network == "zinken" {

--- a/go.sum
+++ b/go.sum
@@ -336,6 +336,7 @@ github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x
 github.com/gballet/go-libpcsclite v0.0.0-20191108122812-4678299bea08 h1:f6D9Hr8xV8uYKlyuj8XIruxlh9WjVjdh1gIicAS7ays=
 github.com/gballet/go-libpcsclite v0.0.0-20191108122812-4678299bea08/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/gzip v0.0.1/go.mod h1:fGBJBCdt6qCZuCAOwWuFhBB4OOq9EFqlo5dEaFhhu5w=
 github.com/gin-contrib/sse v0.0.0-20170109093832-22d885f9ecc7/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=

--- a/rpc/lighthouse.go
+++ b/rpc/lighthouse.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -505,7 +506,7 @@ func (lc *LighthouseClient) GetBlocksBySlot(slot uint64) ([]*types.Block, error)
 		}
 	}
 
-	if payload := parsedBlock.Message.Body.ExecutionPayload; payload != nil {
+	if payload := parsedBlock.Message.Body.ExecutionPayload; payload != nil && binary.BigEndian.Uint64(parsedBlock.Message.Body.ExecutionPayload.ParentHash) != 0 {
 		txs := make([]*types.Transaction, 0, len(payload.Transactions))
 		for _, txUnion := range payload.Transactions {
 			otx := txUnion.Value

--- a/rpc/lighthouse.go
+++ b/rpc/lighthouse.go
@@ -517,8 +517,7 @@ func (lc *LighthouseClient) GetBlocksBySlot(slot uint64) ([]*types.Block, error)
 			tx := &types.Transaction{Raw: rawTx}
 			var decTx gtypes.Transaction
 			if err := decTx.UnmarshalBinary(rawTx); err != nil {
-				logger.Errorf("skipping tx, error parsing tx %d block %x: %v", i, payload.BlockHash, err)
-				continue
+				return nil, fmt.Errorf("error parsing tx %d block %x: %v", i, payload.BlockHash, err)
 			} else {
 				h := decTx.Hash()
 				tx.TxHash = h[:]
@@ -528,8 +527,7 @@ func (lc *LighthouseClient) GetBlocksBySlot(slot uint64) ([]*types.Block, error)
 				tx.GasLimit = decTx.Gas()
 				sender, err := lc.signer.Sender(&decTx)
 				if err != nil {
-					logger.Errorf("skipping tx, transaction with invalid sender (tx hash: %x): %v", h, err)
-					continue
+					return nil, fmt.Errorf("transaction with invalid sender (tx hash: %x): %v", h, err)
 				}
 				tx.Sender = sender.Bytes()
 				if v := decTx.To(); v != nil {

--- a/rpc/lighthouse.go
+++ b/rpc/lighthouse.go
@@ -700,7 +700,7 @@ func (lc *LighthouseClient) GetValidatorParticipation(epoch uint64) (*types.Vali
 func (lc *LighthouseClient) GetFinalityCheckpoints(epoch uint64) (*types.FinalityCheckpoints, error) {
 	// finalityResp, err := lc.get(fmt.Sprintf("%s/eth/v1/beacon/states/%s/finality_checkpoints", lc.endpoint, id))
 	// if err != nil {
-	// 	return nil, fmt.Errorf("error retrieving finality checkpoints of head: %v", err)
+	//      return nil, fmt.Errorf("error retrieving finality checkpoints of head: %v", err)
 	// }
 	return &types.FinalityCheckpoints{}, nil
 }
@@ -961,7 +961,7 @@ type ExecutionPayload struct {
 	GasUsed       uint64Str     `json:"gas_used"`
 	Timestamp     uint64Str     `json:"timestamp"`
 	ExtraData     bytesHexStr   `json:"extra_data"`
-	BaseFeePerGas uint64Str   `json:"base_fee_per_gas"`
+	BaseFeePerGas uint64Str     `json:"base_fee_per_gas"`
 	BlockHash     bytesHexStr   `json:"block_hash"`
 	Transactions  []Transaction `json:"transactions"`
 }

--- a/rpc/lighthouse.go
+++ b/rpc/lighthouse.go
@@ -8,12 +8,13 @@ import (
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
 	"fmt"
-	gtypes "github.com/ethereum/go-ethereum/core/types"
 	"io/ioutil"
 	"net/http"
 	"strconv"
 	"sync"
 	"time"
+
+	gtypes "github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/protolambda/zssz/bitfields"
 
@@ -508,12 +509,10 @@ func (lc *LighthouseClient) GetBlocksBySlot(slot uint64) ([]*types.Block, error)
 
 	if payload := parsedBlock.Message.Body.ExecutionPayload; payload != nil && binary.BigEndian.Uint64(parsedBlock.Message.Body.ExecutionPayload.ParentHash) != 0 {
 		txs := make([]*types.Transaction, 0, len(payload.Transactions))
-		for _, txUnion := range payload.Transactions {
-			otx := txUnion.Value
-
-			tx := &types.Transaction{Raw: otx}
+		for _, rawTx := range payload.Transactions {
+			tx := &types.Transaction{Raw: rawTx}
 			var decTx gtypes.Transaction
-			if err := decTx.UnmarshalBinary(otx); err != nil {
+			if err := decTx.UnmarshalBinary(rawTx); err != nil {
 				h := decTx.Hash()
 				tx.TxHash = h[:]
 				tx.AccountNonce = decTx.Nonce()
@@ -944,11 +943,6 @@ type SyncAggregate struct {
 	SyncCommitteeSignature bytesHexStr `json:"sync_committee_signature"`
 }
 
-type Transaction struct {
-	Selector uint        `json:"selector"`
-	Value    bytesHexStr `json:"value"`
-}
-
 type ExecutionPayload struct {
 	ParentHash    bytesHexStr   `json:"parent_hash"`
 	CoinBase      bytesHexStr   `json:"coinbase"`
@@ -963,7 +957,7 @@ type ExecutionPayload struct {
 	ExtraData     bytesHexStr   `json:"extra_data"`
 	BaseFeePerGas uint64Str     `json:"base_fee_per_gas"`
 	BlockHash     bytesHexStr   `json:"block_hash"`
-	Transactions  []Transaction `json:"transactions"`
+	Transactions  []bytesHexStr `json:"transactions"`
 }
 
 type AnySignedBlock struct {

--- a/rpc/lighthouse.go
+++ b/rpc/lighthouse.go
@@ -541,7 +541,7 @@ func (lc *LighthouseClient) GetBlocksBySlot(slot uint64) ([]*types.Block, error)
 			GasUsed:       uint64(payload.GasUsed),
 			Timestamp:     uint64(payload.Timestamp),
 			ExtraData:     payload.ExtraData,
-			BaseFeePerGas: payload.BaseFeePerGas,
+			BaseFeePerGas: uint64(payload.BaseFeePerGas),
 			BlockHash:     payload.BlockHash,
 			Transactions:  txs,
 		}
@@ -961,7 +961,7 @@ type ExecutionPayload struct {
 	GasUsed       uint64Str     `json:"gas_used"`
 	Timestamp     uint64Str     `json:"timestamp"`
 	ExtraData     bytesHexStr   `json:"extra_data"`
-	BaseFeePerGas bytesHexStr   `json:"base_fee_per_gas"`
+	BaseFeePerGas uint64Str   `json:"base_fee_per_gas"`
 	BlockHash     bytesHexStr   `json:"block_hash"`
 	Transactions  []Transaction `json:"transactions"`
 }

--- a/rpc/lighthouse.go
+++ b/rpc/lighthouse.go
@@ -516,7 +516,7 @@ func (lc *LighthouseClient) GetBlocksBySlot(slot uint64) ([]*types.Block, error)
 		for _, rawTx := range payload.Transactions {
 			tx := &types.Transaction{Raw: rawTx}
 			var decTx gtypes.Transaction
-			if err := decTx.UnmarshalBinary(rawTx); err != nil {
+			if err := decTx.UnmarshalBinary(rawTx); err == nil {
 				h := decTx.Hash()
 				tx.TxHash = h[:]
 				tx.AccountNonce = decTx.Nonce()
@@ -529,7 +529,11 @@ func (lc *LighthouseClient) GetBlocksBySlot(slot uint64) ([]*types.Block, error)
 					continue
 				}
 				tx.Sender = sender.Bytes()
-				tx.Recipient = decTx.To().Bytes()
+				if v := decTx.To(); v != nil {
+					tx.Recipient = v.Bytes()
+				} else {
+					tx.Recipient = []byte{}
+				}
 				tx.Amount = decTx.Value().Bytes()
 				tx.Payload = decTx.Data()
 				tx.MaxPriorityFeePerGas = decTx.GasTipCap().Uint64()

--- a/rpc/prysm.go
+++ b/rpc/prysm.go
@@ -5,6 +5,8 @@ import (
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
 	"fmt"
+	gtypes "github.com/ethereum/go-ethereum/core/types"
+	"math/big"
 	"sync"
 	"time"
 
@@ -26,11 +28,11 @@ type PrysmClient struct {
 	assignmentsCache    *lru.Cache
 	assignmentsCacheMux *sync.Mutex
 	newBlockChan        chan *types.Block
-	//signer              gtypes.EIP155Signer
+	signer              gtypes.Signer
 }
 
 // NewPrysmClient is used for a new Prysm client connection
-func NewPrysmClient(endpoint string, chainId int64) (*PrysmClient, error) {
+func NewPrysmClient(endpoint string, chainId *big.Int) (*PrysmClient, error) {
 	dialOpts := []grpc.DialOption{
 		grpc.WithInsecure(),
 		// Maximum receive value 128 MB
@@ -52,7 +54,7 @@ func NewPrysmClient(endpoint string, chainId int64) (*PrysmClient, error) {
 		conn:                conn,
 		assignmentsCacheMux: &sync.Mutex{},
 		newBlockChan:        make(chan *types.Block, 1000),
-		//signer:              gtypes.NewEIP155Signer(big.NewInt(chainId)),
+		signer:              gtypes.NewLondonSigner(chainId),
 	}
 	client.assignmentsCache, _ = lru.New(10)
 

--- a/tables.sql
+++ b/tables.sql
@@ -297,13 +297,13 @@ create table blocks_transactions
     txhash             bytea  not null,
     nonce              int    not null,
     gas_price          bytea  not null,
-    gas_limit          int    not null,
+    gas_limit          bigint not null,
     sender             bytea  not null,
     recipient          bytea  not null,
     amount             bytea  not null,
     payload            bytea  not null,
-    max_priority_fee_per_gas  int,
-    max_fee_per_gas           int,
+    max_priority_fee_per_gas  bigint,
+    max_fee_per_gas           bigint,
     primary key (block_slot, block_index)
 );
 
@@ -626,29 +626,29 @@ CREATE TABLE stats_meta_p (
     created_trunc       timestamp   not null,
     exporter_version    varchar(35),
     day                 int,
-	
+
 	user_id 		 	bigint	 	 		        not null,
     primary key (id, day)
-    
+
 ) PARTITION BY LIST (day);
 
 drop table if exists stats_process;
 CREATE TABLE stats_process (
 	id 				bigserial 			primary key,
-	
+
 	cpu_process_seconds_total 	bigint   			not null,
-	
+
 	memory_process_bytes	 	bigint	 	 		not null,
-	
+
 	client_name 			character varying(25)  	not null,
 	client_version		 	character varying(25)	 	not null,
 	client_build		 	int 				not null,
-	
+
 	sync_eth2_fallback_configured  bool 				not null,
 	sync_eth2_fallback_connected 	bool	 			not null,
-	
+
 	meta_id 	 		bigint    			not null,
-	
+
 	foreign key(meta_id) references stats_meta(id)
 );
 create index idx_stats_process_metaid on stats_process (meta_id);
@@ -666,9 +666,9 @@ CREATE TABLE stats_add_beaconnode (
 	sync_beacon_head_slot	 		bigint	 		not null,
     sync_eth1_fallback_configured  bool	 			not null,
 	sync_eth1_fallback_connected 	bool	 			not null,
-	
+
 	general_id		 		bigint	 		not null,
-	
+
 	foreign key(general_id) references stats_process(id)
 );
 create index idx_stats_beaconnode_generalid on stats_add_beaconnode (general_id);
@@ -678,9 +678,9 @@ CREATE TABLE stats_add_validator (
 	id		 			bigserial	 	primary key,
 	validator_total 			int	 		not null,
 	validator_active	 		int	 		not null,
-	
+
 	general_id	 			bigint		 	not null,
-	
+
 	foreign key(general_id) references stats_process(id)
 );
 create index idx_stats_beaconnode_validator on stats_add_validator (general_id);
@@ -691,33 +691,33 @@ CREATE TABLE stats_system (
 
 	cpu_cores 				int	 		not null,
 	cpu_threads 				int	 		not null,
-	
+
 	cpu_node_system_seconds_total  	bigint 		not null,
 	cpu_node_user_seconds_total 		bigint	 		not null,
 	cpu_node_iowait_seconds_total	 	bigint	 		not null,
 	cpu_node_idle_seconds_total	 	bigint	 		not null,
-	
+
 	memory_node_bytes_total 		bigint	 		not null,
 	memory_node_bytes_free	 		bigint	 		not null,
 	memory_node_bytes_cached 		bigint	 		not null,
 	memory_node_bytes_buffers 		bigint	 		not null,
-	
+
 	disk_node_bytes_total	 		bigint	 		not null,
 	disk_node_bytes_free	 		bigint	 		not null,
-	
+
 	disk_node_io_seconds	 		bigint	 		not null,
 	disk_node_reads_total	 		bigint	 		not null,
 	disk_node_writes_total	 		bigint 		not null,
-	
+
 	network_node_bytes_total_receive 	bigint	 		not null,
 	network_node_bytes_total_transmit 	bigint	 		not null,
-	
+
 	misc_node_boot_ts_seconds	 	bigint		 	not null,
 	misc_os		 		character varying(6)  	not null,
-	
+
 	meta_id	 			bigint		 	not null,
-	
-	
+
+
 	foreign key(meta_id) references stats_meta(id)
 );
 
@@ -726,11 +726,11 @@ create index idx_stats_system_meta_id on stats_system (meta_id);
 drop table if exists stake_pools_stats;
 create table stake_pools_stats
 (
-    id serial not null, 
-    address text not null, 
-    deposit int, 
-    name text not null, 
-    category text, 
+    id serial not null,
+    address text not null,
+    deposit int,
+    name text not null,
+    category text,
     PRIMARY KEY(id, address, deposit, name)
 );
 
@@ -752,9 +752,9 @@ drop table if exists staking_pools_chart;
 create table staking_pools_chart
 (
     epoch                      int  not null,
-    name                       text not null, 
-    income                     bigint not null, 
-    balance                    bigint not null, 
+    name                       text not null,
+    income                     bigint not null,
+    balance                    bigint not null,
     PRIMARY KEY(epoch, name)
 );
 

--- a/types/config.go
+++ b/types/config.go
@@ -151,6 +151,8 @@ type Config struct {
 type Phase0 struct {
 	ConfigName string `yaml:"CONFIG_NAME"` // the name of the configuration e.g. mainnet
 
+	GenesisForkVersion string `yaml:"GENESIS_FORK_VERSION"`
+
 	// Misc constants.
 	MaxCommitteesPerSlot           uint64 `yaml:"MAX_COMMITTEES_PER_SLOT"`            // MaxCommitteesPerSlot defines the max amount of committee in a single slot.
 	TargetCommitteeSize            uint64 `yaml:"TARGET_COMMITTEE_SIZE"`              // TargetCommitteeSize is the number of validators in a committee when the chain is healthy.

--- a/types/exporter.go
+++ b/types/exporter.go
@@ -143,7 +143,7 @@ type ExecutionPayload struct {
 	GasUsed       uint64
 	Timestamp     uint64
 	ExtraData     []byte
-	BaseFeePerGas []byte
+	BaseFeePerGas uint64
 	BlockHash     []byte
 	Transactions  []*Transaction
 }


### PR DESCRIPTION
Not sure why BaseFeePerGas was of type `[]byte`, but i switched it to use uint64 instead (same as GasUsed). The PR changes the type defined in the `types/exporter.go` as well as the struct in `rpc/lighthouse.go`. I removed the slice defined in `db/db.go` since we now use a `uint64`. 

I've additionally added a check for non-0 `ParentHash` before parsing the execution payload. We now only parse the payload when there is one to parse. 

So we now write and read the BaseFeePerGas information as `uint64`. Deployed the fix in `merge-devops-0.wenmerge.dev`, it works fine on both pre-merge, merge-enabled and post-merge blocks. 


