### PR TITLE
fix transaction unmarshal

### DIFF
--- a/rpc/lighthouse.go
+++ b/rpc/lighthouse.go
@@ -8,12 +8,13 @@ import (
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
 	"fmt"
-	gtypes "github.com/ethereum/go-ethereum/core/types"
 	"io/ioutil"
 	"net/http"
 	"strconv"
 	"sync"
 	"time"
+
+	gtypes "github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/protolambda/zssz/bitfields"
 
@@ -508,12 +509,10 @@ func (lc *LighthouseClient) GetBlocksBySlot(slot uint64) ([]*types.Block, error)
 
 	if payload := parsedBlock.Message.Body.ExecutionPayload; payload != nil && binary.BigEndian.Uint64(parsedBlock.Message.Body.ExecutionPayload.ParentHash) != 0 {
 		txs := make([]*types.Transaction, 0, len(payload.Transactions))
-		for _, txUnion := range payload.Transactions {
-			otx := txUnion.Value
-
-			tx := &types.Transaction{Raw: otx}
+		for _, rawTx := range payload.Transactions {
+			tx := &types.Transaction{Raw: rawTx}
 			var decTx gtypes.Transaction
-			if err := decTx.UnmarshalBinary(otx); err != nil {
+			if err := decTx.UnmarshalBinary(rawTx); err != nil {
 				h := decTx.Hash()
 				tx.TxHash = h[:]
 				tx.AccountNonce = decTx.Nonce()
@@ -944,11 +943,6 @@ type SyncAggregate struct {
 	SyncCommitteeSignature bytesHexStr `json:"sync_committee_signature"`
 }
 
-type Transaction struct {
-	Selector uint        `json:"selector"`
-	Value    bytesHexStr `json:"value"`
-}
-
 type ExecutionPayload struct {
 	ParentHash    bytesHexStr   `json:"parent_hash"`
 	CoinBase      bytesHexStr   `json:"coinbase"`
@@ -963,7 +957,7 @@ type ExecutionPayload struct {
 	ExtraData     bytesHexStr   `json:"extra_data"`
 	BaseFeePerGas uint64Str     `json:"base_fee_per_gas"`
 	BlockHash     bytesHexStr   `json:"block_hash"`
-	Transactions  []Transaction `json:"transactions"`
+	Transactions  []bytesHexStr `json:"transactions"`
 }
 
 type AnySignedBlock struct {


### PR DESCRIPTION
Should fix:

```
time="2021-12-08T17:22:29Z" level=error msg="error parsing block data at slot 8486: json: cannot unmarshal string into Go struct field ExecutionPayload.data.message.body.execution_payload.transactions of type rpc.Transaction" module=rpc
```

Transactions come in like:

```
"execution_payload": {
  "transactions": [                                       
   "0xf8688204aa843faaf703830927c0942683c6219b2ad47cdc959d49df148af6997345a280808328d227a007ace30d225ae46d402428a855cf51101c444e71d990769f5ca2d9cb958f91489f964c394172d416cf4be31e15523c7ca58a42ceac9c27ad5324574e6bf7d670"                                                                                                                                                                      
  ]
...
}